### PR TITLE
docs: Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+ # Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its Code of Conduct.
+
+By participating in this project, you agree to uphold the standards of respectful and inclusive communication described in the document above.
+
+If you have any questions or experience behavior that violates the Code of Conduct, please contact the project maintainer.
+
+— SoundBlaster


### PR DESCRIPTION
Add standard Code of Conduct by linking to the https://www.contributor-covenant.org